### PR TITLE
Update Gradle build command and add artifact upload step to Android build workflow

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -39,4 +39,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: app-release
-        path: app/build/outputs/apk/release/app-release.apk
+        path: app/build/outputs/apk/release/app-release-unsigned.apk

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -34,3 +34,9 @@ jobs:
 
     - name: Build with Gradle
       run: ./gradlew assmbleRelease
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v2
+      with:
+        name: app-release
+        path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -33,7 +33,7 @@ jobs:
       run: chmod +x ./gradlew
 
     - name: Build with Gradle
-      run: ./gradlew assmbleRelease
+      run: ./gradlew assembleRelease
 
     - name: Upload APK
       uses: actions/upload-artifact@v2

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -33,4 +33,4 @@ jobs:
       run: chmod +x ./gradlew
 
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew assmbleRelease


### PR DESCRIPTION
This pull request updates the Gradle build command in the Android build workflow to use "assembleRelease" instead of "build". It also adds a new step to upload the generated APK artifact.