### PR TITLE
Add max_line_length to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,4 @@ insert_final_newline = true
 
 [*.{kt,kts}]
 ktlint_function_naming_ignore_when_annotated_with=Composable
+max_line_length = 180


### PR DESCRIPTION
This pull request adds the `max_line_length` property to the `.editorconfig` file. The `max_line_length` property is set to 180, which ensures that lines in the codebase do not exceed this limit. This helps maintain code readability and consistency.